### PR TITLE
fix repetition of addEventListener for promotion

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -34,10 +34,10 @@
     </div>
     <div id="promotionModal" style="display: none;">
         <p>Choose a piece to promote to:</p>
-        <button id="queenPromoButton">Queen</button>
-        <button id="rookPromoButton">Rook</button>
-        <button id="bishopPromoButton">Bishop</button>
-        <button id="knightPromoButton">Knight</button>
+        <button data-piece="q">Queen</button>
+        <button data-piece="r">Rook</button>
+        <button data-piece="b">Bishop</button>
+        <button data-piece="n">Knight</button>
     </div>
 </body>
 

--- a/client/js/index.js
+++ b/client/js/index.js
@@ -1,17 +1,10 @@
 import init, { get_engine_move } from "../pkg/chess_engine.js";
 import { openGameOverModal } from "./game_over.js";
 
-document.getElementById("queenPromoButton").addEventListener("click", () => {
-    handlePromotion('q')
-}, false);
-document.getElementById("rookPromoButton").addEventListener("click", () => {
-    handlePromotion('r')
-}, false);
-document.getElementById("bishopPromoButton").addEventListener("click", () => {
-    handlePromotion('b')
-}, false);
-document.getElementById("knightPromoButton").addEventListener("click", () => {
-    handlePromotion('n')
+document.getElementById("promotionModal").addEventListener("click", (e) => {
+    if (e.target.tagName === "BUTTON") {
+        handlePromotion(e.target.dataset.piece);
+    }
 }, false);
 
 let promotionData;

--- a/client/js/index.js
+++ b/client/js/index.js
@@ -89,3 +89,8 @@ function makeMove(source, target, oldPos, promo) {
         }
     });
 }
+
+// for testing (for now)
+window.setBoardState = function (state) {
+    board.position(state);
+}


### PR DESCRIPTION
* DRY'd repetition of addEventListener for promotion modals
* added global `setBoardState` function for testing in the console
  * I used `setBoardState("rnbqk3/ppppp2P/8/8/8/8/PPPPPPP1/RNBQKBNR w KQq - 0 1")` to test promotion