### PR TITLE
add linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,15 @@ Chess engine in Rust that compiles to WASM
 
 [View the game](https://minecraftu.github.io/2023-computer-adventures/)
 
-## compile & run instructions
+## Compile & run instructions
 
 ```
 wasm-pack build --target web --out-dir client/pkg
 cd client && python3 -m http.server
 ```
+
+## Linting
+
+`cargo clippy`
+
+Automatically apply suggestions: `cargo clippy --fix`

--- a/src/evaluate.rs
+++ b/src/evaluate.rs
@@ -44,9 +44,9 @@ fn material(board : &Board) -> f32 {
 }
 
 fn mobility(board : &Board) -> f32 {
-    let black_mobility = MoveGen::new_legal(&board).len() as f32;
+    let black_mobility = MoveGen::new_legal(board).len() as f32;
     let new_board = board.null_move();
-    if new_board == None {
+    if new_board.is_none() {
         return 0.0;
     }
     let white_mobility = MoveGen::new_legal(&new_board.unwrap()).len() as f32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::needless_return)]
 use chess::{Piece, Board, ChessMove, Square, MoveGen};
 use wasm_bindgen::prelude::*;
 use std::str::FromStr;
@@ -30,7 +31,7 @@ pub fn get_engine_move(board_str : &str, source_str: &str, target_str: &str, pro
     }
 
     let engine_move_option = search::search(&result.unwrap());
-    if engine_move_option == None {
+    if engine_move_option.is_none() {
         if result.unwrap().checkers().popcnt() == 0 {
             return String::from("stalemate after player move");
         } else {
@@ -47,9 +48,9 @@ pub fn get_engine_move(board_str : &str, source_str: &str, target_str: &str, pro
     
     if MoveGen::new_legal(&engine_result.unwrap()).len() == 0 {
         if engine_result.unwrap().checkers().popcnt() == 0 {
-            return format!("stalemate after engine move;{}", engine_result.unwrap().to_string());
+            return format!("stalemate after engine move;{}", engine_result.unwrap());
         } else {
-            return format!("checkmate, engine won;{}", engine_result.unwrap().to_string());
+            return format!("checkmate, engine won;{}", engine_result.unwrap());
         }
     }
 
@@ -69,7 +70,7 @@ fn make_move(chess_move : ChessMove, board : &Board) -> Result<Board, &'static s
 
 #[cfg(test)]
 mod tests {
-    use pprof;
+    
     use pprof::protos::Message;
     use std::fs::File;
     use std::io::Write;

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,7 +11,7 @@ pub fn alpha_beta_max(mut alpha : f32, beta : f32, depth : i32, board : &Board) 
     if depth == 0 {
         return evaluate::evaluate(board);
     };
-    for chess_move in MoveGen::new_legal(&board) {
+    for chess_move in MoveGen::new_legal(board) {
         let mut result = *board;
         board.make_move(chess_move, &mut result);
         let score: f32 = alpha_beta_min(alpha, beta, depth - 1, &result);
@@ -29,7 +29,7 @@ pub fn alpha_beta_min(alpha : f32, mut beta : f32, depth : i32, board : &Board) 
     if depth == 0 {
         return evaluate::evaluate(board);
     };
-    for chess_move in MoveGen::new_legal(&board) {
+    for chess_move in MoveGen::new_legal(board) {
         let mut result = *board;
         board.make_move(chess_move, &mut result);
         let score: f32 = alpha_beta_max(alpha, beta, depth - 1, &result);
@@ -48,7 +48,7 @@ pub fn search(board : &Board) -> Option<ChessMove> {
     let mut best_move: Option<ChessMove> = None;
     let mut max: f32 = f32::MIN;
     // let mut move_hist = 
-    for chess_move in MoveGen::new_legal(&board) {
+    for chess_move in MoveGen::new_legal(board) {
         let mut result = *board;
         board.make_move(chess_move, &mut result);
         let score: f32 = alpha_beta_min(f32::MIN, f32::MAX, 3, &result);


### PR DESCRIPTION
adds rust linter

To run linter: `cargo clippy` or `cargo clippy --fix` to auto fix

Added `#![allow(clippy::needless_return)]` to top of `lib.rs` to not warn on explicit return when implicit return is possible
